### PR TITLE
Fix broken link to frontend quality article

### DIFF
--- a/content/docs/website/demarrer.md
+++ b/content/docs/website/demarrer.md
@@ -11,7 +11,7 @@ Comme les sites sont développés avec Hugo, il faut l'installer pour coder en l
 
 Cela se fait tout seul quand on crée le site dans l'admin Osuny, il suffit de cloner le référentiel.
 
-> Avant le template AAA, il y a eu un autre template, nommé [osuny-hugo-template](https://github.com/noesya/osuny-hugo-template), qui utilisait le thème [osuny-hugo-theme](https://github.com/noesya/osuny-hugo-theme). Ce template et ce thème sont obsolètes. Il a fait l'objet de plusieurs refontes, et a lui-même succédé au thème Jekyll, au début d'Osuny. La mention AAA se réfère à l'article [Qualité frontend : à la recherche du AAA](https://lab.noesya.coop/2022/qualite-front), publié sur le [Lab noesya](https://lab.noesya.coop).
+> Avant le template AAA, il y a eu un autre template, nommé [osuny-hugo-template](https://github.com/noesya/osuny-hugo-template), qui utilisait le thème [osuny-hugo-theme](https://github.com/noesya/osuny-hugo-theme). Ce template et ce thème sont obsolètes. Il a fait l'objet de plusieurs refontes, et a lui-même succédé au thème Jekyll, au début d'Osuny. La mention AAA se réfère à l'article [Qualité frontend : à la recherche du AAA](https://lab.noesya.coop/publications/2022-05-09-qualite-frontend/), publié sur le [Lab noesya](https://lab.noesya.coop).
 
 ## Installer Hugo
 


### PR DESCRIPTION
En découvrant Osuny, je suis tombé sur un lien cassé vers l’article [Qualité frontend : à la recherche du AAA](https://lab.noesya.coop/publications/2022-05-09-qualite-frontend/)

Cette toute petite PR corrige le lien.

Passez une bonne journée !